### PR TITLE
Add speed tests model/migration and speed test worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.0.0-alpine
-RUN apk add --update build-base mariadb-dev tzdata nodejs mysql-client && rm -rf /var/cache/apk/*
+RUN apk add --update build-base mariadb-dev tzdata nodejs mysql-client speedtest-cli && rm -rf /var/cache/apk/*
 ADD . /app
 WORKDIR /app
 

--- a/app/models/speed_test.rb
+++ b/app/models/speed_test.rb
@@ -1,0 +1,15 @@
+class SpeedTest < ApplicationRecord
+  ALLOWED_STATUSES = %w[running finished failed]
+
+  validates :status, inclusion: { in: ALLOWED_STATUSES }
+
+  def update_with_json(json_string)
+    json = JSON.parse(json_string)
+    download = (json['download'] / 1_000_000.0).round
+    upload = (json['upload'] / 1_000_000.0).round
+    ping = json['ping'].round
+
+    success = update(status: 'finished', ping: ping, download: download, upload: upload)
+    update!(status: 'failed') unless success
+  end
+end

--- a/app/workers/speed_test_worker.rb
+++ b/app/workers/speed_test_worker.rb
@@ -1,7 +1,33 @@
 class SpeedTestWorker
   include Sidekiq::Worker
 
-  def perform(*args)
-    puts "This will be where the speed tests happen"
+  COMMAND = 'speedtest-cli'.freeze
+
+  def perform
+    @speed_test = SpeedTest.create!(status: 'running')
+    @output, @error, @status = Open3.capture3(COMMAND, '--json')
+
+    return handle_success if @status.success?
+
+    handle_failure
+  end
+
+  private
+
+  def handle_success
+    Rails.logger.info('Ran speed test successfully.')
+    Rails.logger.info("OUTPUT:    #{@output}")
+    Rails.logger.info("EXIT CODE: #{@status.to_i}")
+
+    @speed_test.update_with_json(@output)
+  end
+
+  def handle_failure
+    Rails.logger.info('Speed test failed!')
+    Rails.logger.info("OUTPUT:    #{@output}")
+    Rails.logger.info("ERROR:     #{@error}")
+    Rails.logger.info("EXIT CODE: #{@status.to_i}")
+
+    @speed_test.update!(status => 'failed')
   end
 end

--- a/db/migrate/20210929141539_create_speed_tests.rb
+++ b/db/migrate/20210929141539_create_speed_tests.rb
@@ -1,0 +1,12 @@
+class CreateSpeedTests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :speed_tests do |t|
+      t.string :status, null: false
+      t.integer :ping
+      t.integer :download
+      t.integer :upload
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_09_29_141539) do
+
+  create_table "speed_tests", charset: "latin1", force: :cascade do |t|
+    t.string "status", null: false
+    t.integer "ping"
+    t.integer "download"
+    t.integer "upload"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   app:
     build: .
-    command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
     ports:

--- a/test/fixtures/speed_tests.yml
+++ b/test/fixtures/speed_tests.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  status: MyString
+  download: 1
+  upload: 1
+
+two:
+  status: MyString
+  download: 1
+  upload: 1

--- a/test/models/speed_test_test.rb
+++ b/test/models/speed_test_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpeedTestTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Changelog
- Add speed test model & migration to store speed test status & results
  - Add method to model to SpeedTest records straight from a speed test's json output
- Add speed test worker to run speed tests
  - Add worker to cron to run every hour
- Various new docker configurations to set up redis/sidekiq